### PR TITLE
Add find_by methods

### DIFF
--- a/lib/unidata.rb
+++ b/lib/unidata.rb
@@ -1,6 +1,7 @@
 require 'java'
 require 'unidata/asjava.jar'
 require 'unidata/extensions'
+require 'unidata/select_list'
 require 'unidata/connection'
 require 'unidata/field'
 require 'unidata/model'

--- a/lib/unidata/connection.rb
+++ b/lib/unidata/connection.rb
@@ -28,7 +28,7 @@ module Unidata
       command = "SELECT #{filename} TO #{list_number}"
       command << " WITH #{condition}" unless condition.empty?
       @session.command(command).exec
-      @session.select_list list_number
+      SelectList.new(@session.select_list list_number)
     end
 
     def exists?(filename, record_id)

--- a/lib/unidata/connection.rb
+++ b/lib/unidata/connection.rb
@@ -24,6 +24,13 @@ module Unidata
       @session = nil
     end
 
+    def select(filename, condition="", list_number=0)
+      command = "SELECT #{filename} TO #{list_number}"
+      command << " WITH #{condition}" unless condition.empty?
+      @session.command(command).exec
+      @session.select_list list_number
+    end
+
     def exists?(filename, record_id)
       exists = false
 

--- a/lib/unidata/model.rb
+++ b/lib/unidata/model.rb
@@ -23,6 +23,7 @@ module Unidata
       def field(index, name, type=String, options={})
         fields[name.to_sym] = Field.new(index, name, type, options)
         define_attribute_accessor(name)
+        define_attribute_finder(name)
       end
 
       def to_unidata(instance)
@@ -64,6 +65,13 @@ module Unidata
         end
       end
 
+      def find_by(name, value)
+        field_number = "F#{fields[name.to_sym].index.first}"
+        connection.select(filename, "#{field_number} EQ \"#{value}\"").map do |id|
+          find(id)
+        end
+      end
+
       private
       def define_attribute_accessor(attribute_name)
         class_eval <<-end_eval
@@ -73,6 +81,14 @@ module Unidata
 
           def #{attribute_name}=(value)
             write_attribute(:#{attribute_name}, value)
+          end
+        end_eval
+      end
+
+      def define_attribute_finder(attribute_name)
+        instance_eval <<-end_eval
+          def find_by_#{attribute_name}(value)
+            find_by(:#{attribute_name}, value)
           end
         end_eval
       end

--- a/lib/unidata/select_list.rb
+++ b/lib/unidata/select_list.rb
@@ -1,0 +1,31 @@
+module Unidata
+  class SelectList
+    include Enumerable
+
+    def initialize(uniselect_list, should_cache=false)
+      @uniselect_list = uniselect_list
+      @should_cache = should_cache
+      @cache = []
+      @exhausted = false
+    end
+
+    def each &block
+      return [] if @exhausted && !@should_cache
+      if @exhausted
+        @cache.each &block
+      else
+        iterate &block
+      end
+    end
+
+    private
+
+    def iterate
+      until (id = @uniselect_list.next.to_s).empty? do
+        @cache << id if @should_cache
+        yield id
+      end
+      @exhausted = true
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,5 +22,15 @@ def package_local_constructor klass,*values
   raise TypeError,"found no matching constructor for " + klass.to_s + "(" + value.class + ")"
 end
 
+class StubUniSelectList
+  def initialize(items)
+    @items = items.map{|item| item.to_s}
+  end
+
+  def next
+    @items.shift || ""
+  end
+end
+
 RSpec.configure do |config|
 end

--- a/spec/unidata/connection_spec.rb
+++ b/spec/unidata/connection_spec.rb
@@ -84,12 +84,17 @@ describe Unidata::Connection do
       connection.select('NAMES-FILE', 'NAME EQ "JAMES,BILL"')
     end
 
-    it 'returns the correct select list' do
+    it 'fetchs the correct select list' do
       connection.open
       select_list = double
 
       @session.should_receive(:select_list).with(5).and_return(select_list)
-      connection.select('NAMES-FILE', 'NAME EQ "JAMES,BILL"', 5).should be(select_list)
+      connection.select('NAMES-FILE', 'NAME EQ "JAMES,BILL"', 5)
+    end
+
+    it 'returns a SelectList' do
+      connection.open
+      connection.select('NAMES-FILE', 'NAME EQ "JAMES,BILL"').should be_a(Unidata::SelectList)
     end
   end
 

--- a/spec/unidata/connection_spec.rb
+++ b/spec/unidata/connection_spec.rb
@@ -71,6 +71,28 @@ describe Unidata::Connection do
     end
   end
 
+  describe '#select' do
+    before(:each) do
+      @session.stub(:command).and_return(double.as_null_object)
+      @session.stub(:select_list)
+    end
+
+    it 'executes the correct command' do
+      connection.open
+
+      @session.should_receive(:command).with('SELECT NAMES-FILE TO 0 WITH NAME EQ "JAMES,BILL"')
+      connection.select('NAMES-FILE', 'NAME EQ "JAMES,BILL"')
+    end
+
+    it 'returns the correct select list' do
+      connection.open
+      select_list = double
+
+      @session.should_receive(:select_list).with(5).and_return(select_list)
+      connection.select('NAMES-FILE', 'NAME EQ "JAMES,BILL"', 5).should be(select_list)
+    end
+  end
+
   describe '#exists?' do
     before(:each) do
       @file = double('UniFile', :close => nil, :read_field => nil)

--- a/spec/unidata/select_list_spec.rb
+++ b/spec/unidata/select_list_spec.rb
@@ -1,15 +1,5 @@
 require 'spec_helper'
 
-class StubUniSelectList
-  def initialize(items)
-    @items = items.map{|item| item.to_s}
-  end
-
-  def next
-    @items.shift || ""
-  end
-end
-
 describe Unidata::SelectList do
   def create_list(items, should_cache=false)
     list = StubUniSelectList.new(items)

--- a/spec/unidata/select_list_spec.rb
+++ b/spec/unidata/select_list_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+class StubUniSelectList
+  def initialize(items)
+    @items = items.map{|item| item.to_s}
+  end
+
+  def next
+    @items.shift || ""
+  end
+end
+
+describe Unidata::SelectList do
+  def create_list(items, should_cache=false)
+    list = StubUniSelectList.new(items)
+    Unidata::SelectList.new(list, should_cache)
+  end
+
+  let(:list) { create_list ['1', '2', '3'] }
+
+  describe '#each' do
+    it 'should yield each of the items in the select list' do
+      expect {|b| list.each &b }.to yield_successive_args '1', '2', '3'
+    end
+
+    context 'without caching' do
+      it 'should only be able to iterate once' do
+        list.each{|i| i}
+        expect {|b| list.each &b }.not_to yield_control
+      end
+    end
+
+    context 'with caching' do
+      it 'should be able to iterate many times' do
+        list = create_list ['1', '2', '3'], true
+        list.each{|i| i}
+        expect {|b| list.each &b }.to yield_successive_args '1', '2', '3'
+      end
+    end
+  end
+
+  it 'should have the enumerable methods' do
+    list.map{|i| ":#{i}:" }.should == [':1:', ':2:', ':3:']
+  end
+end


### PR DESCRIPTION
These will be helpful for some of the upcoming features we need to implement with regards to finding existing contracts. The find_by methods return an array, which is different from the ActiveRecord convention of find_by returning a single contract. This doesn't bother me but if you would like a to use a different name that is fine.
