### PR TITLE
Subclasses of Unidata::Model can be subclassed and share their field definitions

### DIFF
--- a/lib/unidata/connection.rb
+++ b/lib/unidata/connection.rb
@@ -32,43 +32,33 @@ module Unidata
     end
 
     def exists?(filename, record_id)
-      exists = false
-
       open_file(filename) do |file|
         begin
-          file.read_field(record_id, 0)
-          exists = true
+          !!file.read_field(record_id, 0)
         rescue Unidata::UniFileException
+          false
         end
       end
-
-      exists
     end
 
     def read(filename, record_id)
-      record = nil
-
       open_file(filename) do |file|
         begin
-          record = Unidata::UniDynArray.new(file.read(record_id))
+          Unidata::UniDynArray.new(file.read(record_id))
         rescue Unidata::UniFileException
+          nil
         end
       end
-
-      record
     end
 
     def read_field(filename, record_id, field)
-      value = nil
-
       open_file(filename) do |file|
         begin
-          value = file.read_field(record_id, field).to_s
+          file.read_field(record_id, field).to_s
         rescue Unidata::UniFileException
+          nil
         end
       end
-
-      value
     end
 
     def write(filename, record_id, record)

--- a/lib/unidata/model.rb
+++ b/lib/unidata/model.rb
@@ -3,17 +3,20 @@ module Unidata
     class << self
       attr_accessor :filename
 
+      def inherited(subclass)
+        subclass.instance_variable_set(:@fields, {})
+      end
+
       def connection
         Unidata.connection
       end
 
       def fields
-        unless @fields
-          @fields = {}
-          field(0, :id)
+        if self < Unidata::Model
+          superclass.fields.merge @fields
+        else
+          @fields
         end
-
-        @fields
       end
 
       def field?(name)
@@ -21,7 +24,7 @@ module Unidata
       end
 
       def field(index, name, type=String, options={})
-        fields[name.to_sym] = Field.new(index, name, type, options)
+        @fields[name.to_sym] = Field.new(index, name, type, options)
         define_attribute_accessor(name)
         define_attribute_finder(name)
       end
@@ -107,6 +110,9 @@ module Unidata
         end_eval
       end
     end
+
+    @fields = {}
+    field 0, :id
 
     def initialize(attributes={})
       initialize_attributes

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'simplecov'
 require 'coveralls'
 
+MultiJson.engine = :json_pure
+
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do
   add_filter '/spec/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,13 +12,15 @@ require 'rspec'
 require 'time'
 require 'unidata'
 
-def package_local_constructor klass,*values
+def package_local_constructor klass, *values
   constructors = klass.java_class.declared_constructors
   constructors.each do |c|
     c.accessible = true
     begin
       return c.new_instance(*values).to_java
     rescue TypeError
+      false
+    rescue ArgumentError
       false
     end
   end

--- a/spec/unidata/connection_spec.rb
+++ b/spec/unidata/connection_spec.rb
@@ -140,7 +140,7 @@ describe Unidata::Connection do
 
   describe '#read' do
     before(:each) do
-      @file = double('UniFile', :close => nil, :read => nil)
+      @file = double('UniFile', :close => nil, :read => '')
       @session.stub(:open).and_return(@file)
 
       connection.open

--- a/spec/unidata/model_spec.rb
+++ b/spec/unidata/model_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'set'
 
 describe Unidata::Model do
   subject { Unidata::Model }
@@ -13,6 +14,32 @@ describe Unidata::Model do
     field [4,2],  :job_title
     field [4,3],  :salary,      BigDecimal
     field 5,      :status,      String,     :default => 'active'
+  end
+
+  class SubclassRecord < Record
+    self.filename = 'TESTTEMP'
+
+    field 6,      :another_field
+  end
+
+  def create_field(index, name, type=String, options={})
+    Unidata::Field.new(index, name, type, options)
+  end
+
+  describe 'subclasses' do
+    it "should have the fields of it\'s superclass and it's own fields" do
+      SubclassRecord.fields.keys.to_set.should == [
+        :id,
+        :name,
+        :age,
+        :birth_date,
+        :employer,
+        :job_title,
+        :salary,
+        :status,
+        :another_field,
+      ].to_set
+    end
   end
 
   describe '.connection' do

--- a/unidata.gemspec
+++ b/unidata.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_path  = 'lib'
 
   gem.add_development_dependency 'jruby-openssl'
+  gem.add_development_dependency 'json_pure'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec',     '~> 2.10'
   gem.add_development_dependency 'simplecov', '~> 0.7'


### PR DESCRIPTION
This allows for the definition of fields that can be shared across multiple models and files.

@jisraelsen If this looks good to you, I would appreciate it if you could push a new version of the gem to rubygems.

Thanks
